### PR TITLE
Fixed prompts and :SetOnInteract

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Docs: https://crabzzai.github.io/SimpleDialogue/
 1. Install with Wally:
 ```toml
 [dependencies]
-SimpleDialogue = "crabzzai/simpledialogue@0.1.6"
+SimpleDialogue = "crabzzai/simpledialogue@0.1.7"
 ```
 
 ## Development

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ SimpleDialogue is available as a package through [Wally](https://wally.run/), a 
 
 ```toml
 [dependencies]
-SimpleDialogue = "crabzzai/simpledialogue@0.1.6"
+SimpleDialogue = "crabzzai/simpledialogue@0.1.7"
 ```
 
 3. Run `wally install` to install the package.

--- a/src/Handlers/ProximityPromptHandler.luau
+++ b/src/Handlers/ProximityPromptHandler.luau
@@ -82,15 +82,11 @@ end
 
 local function initializePromptHandling()
 	ProximityPromptService.PromptShown:Connect(function(prompt, inputType)
-		local promptData = (
-			activePrompts[prompt]
-			or {
-				onTriggered = nil,
-				highlight = nil,
-				highlightSpring = nil,
-				fadeOutTask = nil,
-			}
-		) :: PromptData
+		local promptData = activePrompts[prompt]
+
+		if not promptData then
+			return
+		end
 
 		if promptData.fadeOutTask then
 			task.cancel(promptData.fadeOutTask)

--- a/src/System/DialogueSystem.luau
+++ b/src/System/DialogueSystem.luau
@@ -651,8 +651,8 @@ function DialogueSystem.SetDialogueTree(self: DialogueSystem, dialogueTree: Dial
 end
 
 function DialogueSystem.SetOnInteract(self: DialogueSystem, callback: () -> ())
-	if self.currentNPC then
-		self.currentNPC.onInteract = callback
+	if self.npc then
+		self.npc.onInteract = callback
 	end
 end
 

--- a/wally.lock
+++ b/wally.lock
@@ -4,7 +4,7 @@ registry = "test"
 
 [[package]]
 name = "crabzzai/simpledialogue"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [["Fusion", "elttob/fusion@0.2.0"]]
 
 [[package]]

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crabzzai/simpledialogue"
-version = "0.1.6"
+version = "0.1.7"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
- Fixed so it only disable/enable proximity prompts which are a part of the system.
- Fixed so :SetOnInteract will actually be set and run.